### PR TITLE
fix/issue145/replace inline styles with Tailwind responsive classes

### DIFF
--- a/app/manager/page.tsx
+++ b/app/manager/page.tsx
@@ -687,56 +687,12 @@ export default function ManagerDashboard() {
       )}
 
       {/* Main Content */}
-      <style>{`
-        @media (max-width: 1022px) {
-          .dashboard-container {
-            flex-direction: column;
-            gap: 1.5rem;
-          }
-          .dashboard-section {
-            width: 100% !important;
-            height: 500px !important;
-          }
-          .chatbox-container {
-            width: 100% !important;
-            height: 500px !important;
-          }
-        }
-        @media (max-width: 699px) {
-          .notices-calendar-section {
-            flex-direction: column;
-            height: auto !important;
-          }
-          .notices-column {
-            width: 100% !important;
-            height: 500px !important;
-            border-right: none !important;
-            border-bottom: 1px solid var(--border);
-            padding-right: 0 !important;
-            padding-bottom: 1.5rem;
-          }
-          .calendar-column {
-            width: 100% !important;
-            padding-left: 0 !important;
-            padding-top: 1.5rem;
-            display: flex !important;
-            justify-content: center !important;
-            align-items: center !important;
-          }
-          .calendar-column > div {
-            padding-left: 0 !important;
-          }
-        }
-      `}</style>
       <main className="flex justify-center items-stretch gap-10 px-6 mt-8 mb-8">
-        <div
-          className="dashboard-container flex gap-10 items-stretch justify-center w-full"
-          style={{ maxWidth: "2000px" }}
-        >
+        <div className="flex flex-col lg:flex-row gap-6 lg:gap-10 items-stretch justify-center w-full max-w-[2000px]">
           {/* Left: Notices + Calendar */}
-          <section className="dashboard-section notices-calendar-section flex bg-card p-6 shadow-lg w-[60%] h-[70vh] border border-border flex-shrink-0 rounded-lg">
+          <section className="flex flex-col md:flex-row bg-card p-6 shadow-lg w-full lg:w-[60%] h-auto md:h-[500px] lg:h-[70vh] border border-border flex-shrink-0 rounded-lg">
             {/* Notices */}
-            <div className="notices-column w-1/2 pr-6 border-r border-border flex flex-col overflow-y-auto">
+            <div className="w-full md:w-1/2 h-[500px] md:h-auto pb-6 md:pb-0 md:pr-6 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-y-auto">
               <NoticeBoard
                 buildingId={buildingId}
                 isManager={true}
@@ -744,7 +700,7 @@ export default function ManagerDashboard() {
             </div>
 
             {/* Calendar */}
-            <div className="calendar-column w-1/2 pl-6">
+            <div className="w-full md:w-1/2 pt-6 md:pt-0 md:pl-6 flex justify-center items-center md:items-start">
               {buildingId ? (
                 <BuildingCalendar buildingId={buildingId} />
               ) : (
@@ -779,7 +735,7 @@ export default function ManagerDashboard() {
                 Direct Messages
               </Link>
             }
-            className="chatbox-container w-[30%]"
+            className="w-full lg:w-[30%] h-[500px] lg:h-[70vh]"
           />
         </div>
       </main>

--- a/app/resident/page.tsx
+++ b/app/resident/page.tsx
@@ -142,61 +142,17 @@ export default function ResidentDashboard() {
       </div>
 
       {/* Main Content */}
-      <style>{`
-        @media (max-width: 1022px) {
-          .dashboard-container {
-            flex-direction: column;
-            gap: 1.5rem;
-          }
-          .dashboard-section {
-            width: 100% !important;
-            height: 500px !important;
-          }
-          .chatbox-container {
-            width: 100% !important;
-            height: 500px !important;
-          }
-        }
-        @media (max-width: 699px) {
-          .notices-calendar-section {
-            flex-direction: column;
-            height: auto !important;
-          }
-          .notices-column {
-            width: 100% !important;
-            height: 500px !important;
-            border-right: none !important;
-            border-bottom: 1px solid var(--border);
-            padding-right: 0 !important;
-            padding-bottom: 1.5rem;
-          }
-          .calendar-column {
-            width: 100% !important;
-            padding-left: 0 !important;
-            padding-top: 1.5rem;
-            display: flex !important;
-            justify-content: center !important;
-            align-items: center !important;
-          }
-          .calendar-column > div {
-            padding-left: 0 !important;
-          }
-        }
-      `}</style>
       <main className="flex justify-center items-start gap-10 px-6 mt-8">
-        <div
-          className="dashboard-container flex gap-10 items-start justify-center w-full"
-          style={{ maxWidth: "2000px" }}
-        >
+        <div className="flex flex-col lg:flex-row gap-6 lg:gap-10 items-start justify-center w-full max-w-[2000px]">
           {/* Left: Notices + Calendar */}
-          <section className="dashboard-section notices-calendar-section flex bg-card p-6 shadow-lg w-[60%] h-[70vh] border border-border rounded-lg">
+          <section className="flex flex-col md:flex-row bg-card p-6 shadow-lg w-full lg:w-[60%] h-auto md:h-[500px] lg:h-[70vh] border border-border rounded-lg">
             {/* Notices */}
-            <div className="notices-column w-1/2 pr-6 border-r border-border flex flex-col overflow-y-auto">
+            <div className="w-full md:w-1/2 h-[500px] md:h-auto pb-6 md:pb-0 md:pr-6 border-b md:border-b-0 md:border-r border-border flex flex-col overflow-y-auto">
               <NoticeBoard buildingId={building.id} />
             </div>
 
             {/* Calendar */}
-            <div className="calendar-column w-1/2 pl-6 flex flex-col items-center">
+            <div className="w-full md:w-1/2 pt-6 md:pt-0 md:pl-6 flex flex-col items-center">
               <BuildingCalendar buildingId={building.id} />
             </div>
           </section>
@@ -225,7 +181,7 @@ export default function ResidentDashboard() {
                 Direct Messages
               </Link>
             }
-            className="chatbox-container w-[30%]"
+            className="w-full lg:w-[30%] h-[500px] lg:h-[70vh]"
           />
         </div>
       </main>

--- a/components/notices/notice-board.tsx
+++ b/components/notices/notice-board.tsx
@@ -395,34 +395,18 @@ export function NoticeBoard({
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      <style>{`
-        @media (max-width: 1219px) {
-          .notice-header {
-            flex-direction: column;
-            align-items: flex-start;
-            gap: 1rem;
-          }
-          .notice-buttons {
-            width: 100%;
-            flex-direction: column;
-          }
-          .notice-action-button {
-            width: 100%;
-          }
-        }
-      `}</style>
-      <div className="notice-header flex justify-between items-center mb-4 flex-shrink-0">
+      <div className="flex flex-col xl:flex-row xl:justify-between xl:items-center items-start gap-4 xl:gap-0 mb-4 flex-shrink-0">
         <h3 className="font-semibold text-lg">
           {showArchived ? "Archived Notices" : "Notices"}
         </h3>
         {!showAddForm && (
-          <div className="notice-buttons flex gap-2">
+          <div className="flex flex-col xl:flex-row gap-2 w-full xl:w-auto">
             {isManager && (
               <Button
                 size="sm"
                 variant={showArchived ? "default" : "outline"}
                 onClick={() => setShowArchived(!showArchived)}
-                className="notice-action-button"
+                className="w-full xl:w-auto"
               >
                 <Archive className="h-4 w-4 mr-1" />
                 {showArchived ? "View Active" : "View Archive"}
@@ -433,7 +417,7 @@ export function NoticeBoard({
                 size="sm"
                 onClick={() => setShowAddForm(true)}
                 disabled={showArchived}
-                className="notice-action-button"
+                className="w-full xl:w-auto"
               >
                 + Add Notice
               </Button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,9 +10,6 @@ export default {
   ],
   theme: {
     extend: {
-      screens: {
-        sm1220: "1220px",
-      },
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",


### PR DESCRIPTION
- Remove duplicated <style> blocks from manager and resident pages
- Replace !important CSS overrides with proper Tailwind breakpoints
- Use standard lg: (1024px), md: (768px), xl: (1280px) breakpoints
- Remove unused sm1220 custom breakpoint from Tailwind config
- Replace inline maxWidth style with Tailwind max-w-[] class