### PR TITLE
feat/issue-37/ split notices into Active/Expired sections with date grouping

### DIFF
--- a/components/notices/config.ts
+++ b/components/notices/config.ts
@@ -67,3 +67,31 @@ export function formatFileSize(bytes: number): string {
   const i = Math.floor(Math.log(bytes) / Math.log(k))
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i]
 }
+
+export function formatDateHeader(dateString: string): string {
+  const date = new Date(dateString)
+  const today = new Date()
+  const yesterday = new Date(today)
+  yesterday.setDate(yesterday.getDate() - 1)
+  const tomorrow = new Date(today)
+  tomorrow.setDate(tomorrow.getDate() + 1)
+
+  const isToday = date.toDateString() === today.toDateString()
+  const isYesterday = date.toDateString() === yesterday.toDateString()
+  const isTomorrow = date.toDateString() === tomorrow.toDateString()
+
+  if (isToday) return "Today"
+  if (isYesterday) return "Yesterday"
+  if (isTomorrow) return "Tomorrow"
+
+  return date.toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: date.getFullYear() !== today.getFullYear() ? "numeric" : undefined,
+  })
+}
+
+export function getDateKey(dateString: string): string {
+  return new Date(dateString).toDateString()
+}

--- a/components/notices/notice-section.tsx
+++ b/components/notices/notice-section.tsx
@@ -1,0 +1,108 @@
+import { Notice } from "./types"
+import { NoticeCard } from "./notice-card"
+import { formatDateHeader, getDateKey } from "./config"
+
+interface NoticeSectionProps {
+  title: string
+  notices: Notice[]
+  isManager: boolean
+  totalResidents: number
+  onEdit: (notice: Notice) => void
+  onDelete: (noticeId: string) => void
+  onTogglePin: (noticeId: string, currentlyPinned: boolean) => void
+  onToggleArchive: (noticeId: string, currentlyArchived: boolean) => void
+  emptyMessage?: string
+}
+
+interface DateGroup {
+  dateKey: string
+  dateLabel: string
+  notices: Notice[]
+}
+
+function groupNoticesByDate(notices: Notice[]): DateGroup[] {
+  const groups: Map<string, Notice[]> = new Map()
+
+  notices.forEach(notice => {
+    const dateKey = getDateKey(notice.created_at)
+    if (!groups.has(dateKey)) {
+      groups.set(dateKey, [])
+    }
+    groups.get(dateKey)!.push(notice)
+  })
+
+  return Array.from(groups.entries()).map(([dateKey, notices]) => ({
+    dateKey,
+    dateLabel: formatDateHeader(notices[0].created_at),
+    notices,
+  }))
+}
+
+export function NoticeSection({
+  title,
+  notices,
+  isManager,
+  totalResidents,
+  onEdit,
+  onDelete,
+  onTogglePin,
+  onToggleArchive,
+  emptyMessage = "No notices.",
+}: NoticeSectionProps) {
+  if (notices.length === 0) {
+    return null
+  }
+
+  // Separate pinned notices (show at top without date grouping)
+  const pinnedNotices = notices.filter(n => n.is_pinned)
+  const unpinnedNotices = notices.filter(n => !n.is_pinned)
+  const dateGroups = groupNoticesByDate(unpinnedNotices)
+
+  return (
+    <div className="space-y-4">
+      <h4 className="font-medium text-sm text-muted-foreground uppercase tracking-wide">
+        {title} ({notices.length})
+      </h4>
+
+      {/* Pinned notices at top */}
+      {pinnedNotices.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground font-medium">Pinned</p>
+          {pinnedNotices.map(notice => (
+            <NoticeCard
+              key={notice.id}
+              notice={notice}
+              isManager={isManager}
+              totalResidents={totalResidents}
+              onEdit={onEdit}
+              onDelete={onDelete}
+              onTogglePin={onTogglePin}
+              onToggleArchive={onToggleArchive}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Date-grouped notices */}
+      {dateGroups.map(group => (
+        <div key={group.dateKey} className="space-y-2">
+          <p className="text-xs text-muted-foreground font-medium">
+            {group.dateLabel}
+          </p>
+          {group.notices.map(notice => (
+            <NoticeCard
+              key={notice.id}
+              notice={notice}
+              isManager={isManager}
+              totalResidents={totalResidents}
+              onEdit={onEdit}
+              onDelete={onDelete}
+              onTogglePin={onTogglePin}
+              onToggleArchive={onToggleArchive}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
- Add formatDateHeader() and getDateKey() utilities for date grouping
- Create NoticeSection component that groups notices by date (Today, Yesterday, etc.)
- Split notice board into Active and Expired sections
- Expired notices (previously hidden) now shown in separate section
- Pinned notices displayed at top of each section